### PR TITLE
Rails 5 support

### DIFF
--- a/bin/rots
+++ b/bin/rots
@@ -89,6 +89,6 @@ end
 puts "\x1B[32mRunning OpenID Test server on port 1123\x1B[0m" if server_options[:verbose]
 begin 
   Rack::Handler::Mongrel.run server, :Port => server_options[:port]
-rescue LoadError
+rescue LoadError, NameError
   Rack::Handler::WEBrick.run server, :Port => server_options[:port]
 end


### PR DESCRIPTION
If `Rack::Handler::Mongrel` is not defined, fall back to WEBrick. This is necessary because Rails 5 no longer sets up Mongrel.